### PR TITLE
If net config is missing do not return err on DEL

### DIFF
--- a/multus/multus.go
+++ b/multus/multus.go
@@ -89,7 +89,9 @@ func consumeScratchNetConf(containerID, dataDir string) ([]byte, error) {
 
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read container data in the path(%q): %v", path, err)
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to read container data in the path(%q): %v", path, err)
+		}
 	}
 
 	return data, err
@@ -288,6 +290,10 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	netconfBytes, err := consumeScratchNetConf(args.ContainerID, in.CNIDir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// Per spec should ignore error if resources are missing / already removed
+			return nil
+		}
 		return fmt.Errorf("Multus: Err in  reading the delegates: %v", err)
 	}
 


### PR DESCRIPTION
Ignore error if netconf is already removed.
Refer to:
https://github.com/containernetworking/cni/commit/74d4cbed764025808389693e61b305efed7889b8