### PR TITLE
Fix API call for new CRD namespace

### DIFF
--- a/multus/multus.go
+++ b/multus/multus.go
@@ -335,11 +335,11 @@ func getnetplugin(client *kubernetes.Clientset, networkname string, primary bool
 		return "", fmt.Errorf("getnetplugin: network name can't be empty")
 	}
 
-	tprclient := fmt.Sprintf("/apis/kubernetes-network.cni.cncf.io/v1/namespaces/default/networks/%s", networkname)
+	tprclient := fmt.Sprintf("/apis/cni.cncf.io/v1/namespaces/default/kubernetes-network/%s", networkname)
 
 	netobjdata, err := client.ExtensionsV1beta1().RESTClient().Get().AbsPath(tprclient).DoRaw()
 	if err != nil {
-		return "", fmt.Errorf("getnetplugin: failed to get TRP, refer Multus README.md for the usage guide: %v", err)
+		return "", fmt.Errorf("getnetplugin: failed to get CRD (result: %s), refer Multus README.md for the usage guide: %v", netobjdata, err)
 	}
 
 	np := netplugin{}


### PR DESCRIPTION
The API endpoint wasn't exactly correct after the initial changes to use the new namespace. I was running a test of the new `dev/network-plumbing-working-group-crd-change`, and found that the API endpoint was in need of a modification.

Was:

```
/apis/kubernetes-network.cni.cncf.io/v1/namespaces/default/networks/%s
```
Which was returning a 404.

Changed endpoint to:

```
/apis/cni.cncf.io/v1/namespaces/default/kubernetes-network/%s
```

(Where `%s` is the particular network name, e.g. a configuration a user has loaded)

I also updated the error output to put the error returned from the API, comments/criticism of that (or any other) change highly appreciated. I mostly put it there as I've run into an error in the same spot a few times, previous due to RBACs being wrong on my end, and this time from it previously returning a 404.

Signed-off-by: dougbtv <dosmith@redhat.com>