### PR TITLE
Fix error type for NoK8sNetworkError

### DIFF
--- a/k8sclient/k8sclient.go
+++ b/k8sclient/k8sclient.go
@@ -30,9 +30,11 @@ import (
 )
 
 // NoK8sNetworkError indicates error, no network in kubernetes
-type NoK8sNetworkError string
+type NoK8sNetworkError struct {
+	message string
+}
 
-func (e NoK8sNetworkError) Error() string { return string(e) }
+func (e *NoK8sNetworkError) Error() string { return string(e.message) }
 
 func createK8sClient(kubeconfig string) (*kubernetes.Clientset, error) {
 
@@ -258,7 +260,7 @@ func GetK8sNetwork(args *skel.CmdArgs, kubeconfig string) ([]map[string]interfac
 	}
 
 	if len(netAnnot) == 0 {
-		return podNet, NoK8sNetworkError("no kubernetes network found")
+		return podNet, &NoK8sNetworkError{"no kubernetes network found"}
 	}
 
 	netObjs, err := parsePodNetworkObject(netAnnot)

--- a/multus/multus.go
+++ b/multus/multus.go
@@ -336,15 +336,17 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	if in.Kubeconfig != "" {
 		podDelegate, r := k8s.GetK8sNetwork(args, in.Kubeconfig)
-		if r != nil && r.Error() == "nonet" {
-			nopodnet = true
-			if !defaultcninetwork {
-				return fmt.Errorf("Multus: Err in getting k8s network from the poc spec, check the pod spec or set delegate for the default network, Refer the README.md: %v", r)
+		if r != nil {
+			if _, ok := r.(*k8s.NoK8sNetworkError); ok {
+				nopodnet = true
+				// no network found from default and annotaed network,
+				// we do nothing to remove network for the pod!
+				if !defaultcninetwork {
+					return fmt.Errorf("Multus: Err in getting k8s network from the poc spec, check the pod spec or set delegate for the default network, Refer the README.md: %v", r)
+				}
+			} else {
+				return fmt.Errorf("Multus: Err in getting k8s network from pod: %v", r)
 			}
-		}
-
-		if r != nil && !defaultcninetwork {
-			return fmt.Errorf("Multus: Err in getting k8s network from pod: %v", r)
 		}
 
 		if len(podDelegate) != 0 {


### PR DESCRIPTION
This fix changes type type for NoK8sNetworkError due to error handling, in #45.
Currently NoK8sNetworkError is not pointer type, just a string, hence we never
get *NoK8sNetworkError. This fix changes it based @One-ders patch.